### PR TITLE
Fix: crash if some options are set but not -n

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To generate a startup script, use following options:
 
 			-a, --app			Path to node.js main js file
 			-e, --env			Export NODE_ENV with ENV value (default production)
-			-n, --name			Application name
+			-n, --appName			Application name
 			-g, --group			Group (default current group id)
 			-u, --user			User (default current user id)
 

--- a/lib/default.js
+++ b/lib/default.js
@@ -9,18 +9,18 @@
 		var template = [
 			'#!/bin/sh',
 			'### BEGIN INIT INFO',
-			'# Provides:          {{name}}',
+			'# Provides:          {{appName}}',
 			'# Required-Start:    $network $syslog',
 			'# Required-Stop:     $network $syslog',
 			'# Default-Start:     2 3 4 5',
 			'# Default-Stop:      0 1 6',
-			'# Short-Description: {{name}}',
-			'# Description:       {{name}}',
+			'# Short-Description: {{appName}}',
+			'# Description:       {{appName}}',
 			'### END INIT INFO',
 			'# PATH should only include /usr/* if it runs after the mountnfs.sh script',
 			'PATH=/sbin:/usr/sbin:/bin:/usr/bin',
-			'DESC={{name}}',
-			'NAME={{name}}',
+			'DESC={{appName}}',
+			'NAME={{appName}}',
 			'APP_ROOT={{appPath}}',
 			'APP_GROUP={{group}}',
 			'APP_USER={{user}}',
@@ -187,7 +187,7 @@
 
 				// Create default options value
 				this.options = {
-					name: this.packageInfo.name,
+					appName: this.packageInfo.name,
 					app: path.join(process.cwd() + '/' + this.packageInfo.appjs),
 					appPath: process.cwd(),
 					group: process.getgid(),
@@ -200,7 +200,7 @@
 					.version('0.0.3')
 					.option('-a, --app [path]', 'Path to node.js main file')
 					.option('-e, --env [value]', 'Export NODE_ENV with value (default production)')
-					.option('-n, --name [value]', 'Application name')
+					.option('-n, --appName [value]', 'Application name')
 					.option('-g, --group [value]', 'Group (default current user id)')
 					.option('-u, --user [value]', 'User (default current group id)');
 			},
@@ -248,13 +248,13 @@
 
 				program.parse(this.process_argv);
 
-				if (!program.app && !program.env && !program.name && !program.group && !program.user)
+				if (!program.app && !program.env && !program.appName && !program.group && !program.user)
 					this.no_options = true;
 
 				if (program.app)
 					this.options.app = program.app;
-				if (program.name)
-					this.options.name = program.name;
+				if (program.appName)
+					this.options.appName = program.appName;
 				if (program.env)
 					this.options.env = program.env;
 				if (program.group)
@@ -294,8 +294,8 @@
 				var tpl = swig.compile(template);
   				var file = tpl(this.options);
 
-  				fs.writeFile(this.options.name, file, function (err) {
-					self.callback(err, "Script daemon file saved to " + self.options.name);
+  				fs.writeFile(this.options.appName, file, function (err) {
+					self.callback(err, "Script daemon file saved to " + self.options.appName);
 				});
 			}
 		};


### PR DESCRIPTION
Replaced option 'name' with 'appName' as 'name' is a already used by commander and is a function (which explains the crash when some options are specified but 'name' is not overwritten)